### PR TITLE
Add support for SPI bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,6 @@ You can find the latest version by go to [adxl345_driver] on the crates.io websi
 ## Contributing
 
 Contributors are welcome.
-I would like to see the hardware drives extended beyond just the I²C interface
-but I currently don't have access to other hardware for development or testing
-using the SPI interface.
 Make sure you have read the [Contributor Covenant Code of Conduct].
 All contributed code will be considered to also be contributed under a [MIT]
 license.

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -1,0 +1,107 @@
+// MIT License
+//
+// Copyright © 2022, Michael Büsch <m@bues.ch>
+// Copyright © 2020-present, Michael Cummings <mgcummings@yahoo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//! This is a simple example of how to use library.
+//!
+//! The example was written assuming Raspberry Pi OS but should work with other
+//! Linux distros with little or no change.
+//!
+//! ## Examples
+//! To build the example use:
+//! ```sh, no_run
+//! cargo build --example spi
+//! ```
+//! Then to run use:
+//! ```sh, no_run
+//! sudo ./target/debug/examples/spi
+//! ```
+//!
+//! Output example:
+//! ```sh, no_run
+//! axis: {'x': 1.6083, 'y': 0.0392, 'z': 8.7868} m/s²
+//! axis: {'x': 1.6867, 'y': 0.1177, 'z': 8.7868} m/s²
+//! axis: {'x': 1.6475, 'y': 0.1177, 'z': 8.8260} m/s²
+//! ...
+//! ```
+
+use adxl345_driver::{spi::Device, Adxl345Reader, Adxl345Writer};
+use anyhow::{Context, Result};
+use rppal::system::DeviceInfo;
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    sync::Arc,
+    thread::sleep,
+    time::Duration,
+};
+
+/// Output scale is 4mg/LSB.
+const SCALE_MULTIPLIER: f64 = 0.004;
+/// Average Earth gravity in m/s²
+const EARTH_GRAVITY_MS2: f64 = 9.80665;
+
+/// Entry point of example.
+fn main() -> Result<()> {
+    println!(
+        "SPI example started on a {}",
+        DeviceInfo::new()
+            .context("Failed to get new DeviceInfo")?
+            .model()
+    );
+    let mut adxl345 = Device::new().context("Failed to get instance")?;
+    let id = adxl345.device_id().context("Failed to get device id")?;
+    println!("Device id = {}", id);
+    // Set full scale output and range to 2G.
+    adxl345
+        .set_data_format(8)
+        .context("Failed to set data format")?;
+    // Set measurement mode on.
+    adxl345
+        .set_power_control(8)
+        .context("Failed to turn on measurement mode")?;
+    // Stuff needed to nicely handle Ctrl-C from user.
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })
+    .context("Error setting Ctrl-C handler")?;
+    // Loop until Ctrl-C is received.
+    while running.load(Ordering::SeqCst) {
+        let (x, y, z) = adxl345
+            .acceleration()
+            .context("Failed to get acceleration data")?;
+        let x = x as f64 * SCALE_MULTIPLIER * EARTH_GRAVITY_MS2;
+        let y = y as f64 * SCALE_MULTIPLIER * EARTH_GRAVITY_MS2;
+        let z = z as f64 * SCALE_MULTIPLIER * EARTH_GRAVITY_MS2;
+        println!(
+            "axis: {{'x': {:1.4}, 'y': {:1.4}, 'z': {:1.4}}} m/s²",
+            x, y, z
+        );
+        sleep(Duration::from_millis(100));
+    }
+    // Set measurement mode off.
+    adxl345
+        .set_power_control(0)
+        .context("Failed to turn on measurement mode")?;
+    println!("\nSPI example stopped");
+    Ok(())
+}

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -626,6 +626,24 @@ pub trait Adxl345Writer {
     }
 }
 
+pub(crate) trait Adxl345Init: Adxl345Writer {
+    fn init_registers(&mut self, spi_3wire: bool) -> Result {
+        let register = 0x31;
+        self.command(register, if spi_3wire { 1 << 6 } else { 0 })?;
+        for register in 0x1du8..=0x2a {
+            self.command(register, 0)?;
+        }
+        let register = 0x2c;
+        self.command(register, 0x0a)?;
+        for register in 0x2du8..=0x2f {
+            self.command(register, 0)?;
+        }
+        let register = 0x38;
+        self.command(register, 0)?;
+        Ok(())
+    }
+}
+
 // Activity/Inactivity control mode.
 bitflags! {
     /// Activity mode bit flags used in [activity_control()] and

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,12 @@ pub enum AdxlError {
     /// Used to pass through any underlying I²C errors.
     #[error("I²C interface access failed")]
     I2c(#[from] rppal::i2c::Error),
+    /// Used to pass through any underlying SPI errors.
+    #[error("SPI interface access failed")]
+    Spi(#[from] rppal::spi::Error),
+    /// Invalid bus parameters.
+    #[error("Invalid bus parameters")]
+    InvalidBusParams,
     /// Used when given an un-excepted value for a mode.
     #[error("Received one or more set unknown mode bit(s) in value: {0}")]
     UnknownModeBit(u8),

--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -23,7 +23,7 @@
 
 use rppal::i2c::I2c;
 
-use crate::{Adxl345, Adxl345Reader, Adxl345Writer, AdxlResult, Result};
+use crate::{Adxl345, Adxl345Reader, Adxl345Writer, Adxl345Init, AdxlResult, Result};
 
 /// I²C driver structure for the device.
 #[derive(Debug)]
@@ -55,6 +55,7 @@ impl Device {
 }
 
 impl Adxl345 for Device {}
+impl Adxl345Init for Device {}
 
 impl Adxl345Reader for Device {
     fn access(&self, register: u8) -> AdxlResult<u8> {
@@ -80,18 +81,6 @@ impl Adxl345Writer for Device {
         Ok(())
     }
     fn init(&mut self) -> Result {
-        for register in 0x1du8..=0x2a {
-            self.command(register, 0)?;
-        }
-        let register = 0x2c;
-        self.command(register, 0x0a)?;
-        for register in 0x2du8..=0x2f {
-            self.command(register, 0)?;
-        }
-        let register = 0x31;
-        self.command(register, 0)?;
-        let register = 0x38;
-        self.command(register, 0)?;
-        Ok(())
+        self.init_registers(false)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ extern crate c2rust_bitfields;
 mod cmd;
 mod error;
 pub mod i2c;
+pub mod spi;
 
 pub use crate::{
     cmd::{
@@ -40,3 +41,4 @@ pub use crate::{
     },
     error::{AdxlError, AdxlResult, Result},
 };
+pub(crate) use crate::cmd::Adxl345Init;

--- a/src/spi/README.md
+++ b/src/spi/README.md
@@ -1,6 +1,0 @@
-# SPI README
-
-The ADXL345 support a SPI interface as well, but as the original developer
-(Michael Cummings) only have access to a device on an existing board with the
-I²C interface that is what's been include.
-Pull requests for a SPI driven device are welcome.

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -1,0 +1,136 @@
+// MIT License
+//
+// Copyright © 2022, Michael Büsch <m@bues.ch>
+// Copyright © 2020-present, Michael Cummings <mgcummings@yahoo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//! Contains the SPI driver for the device.
+
+use rppal::spi::{Spi, Bus, SlaveSelect, Mode};
+
+use crate::{Adxl345, Adxl345Reader, Adxl345Writer, Adxl345Init, AdxlError, AdxlResult, Result};
+
+/// SPI driver structure for the device.
+#[derive(Debug)]
+pub struct Device {
+    /// Holds the bus interface from the [RPPAL SPI] peripheral.
+    ///
+    /// [RPPAL SPI]: https://docs.golemparts.com/rppal/0.13.1/rppal/spi/index.html
+    bus: Spi,
+    /// true: SPI 3-wire mode; false: SPI 4-wire mode.
+    three_wire: bool,
+}
+
+impl Device {
+    /// Constructor with default bus parameters.
+    ///
+    /// bus = 0; slave_select = 0; clock_speed = 1 MHz; 4-wire-SPI.
+    pub fn new() -> AdxlResult<Self> {
+        Self::with_bus(0, 0, 1_000_000, false)
+    }
+    /// Constructor with bus index and slave-select index.
+    ///
+    /// ## Arguments
+    /// * `bus` - SPI bus index (0-2).
+    /// * `slave_select` - SPI slave-select index (0-2).
+    /// * `clock_speed` - SPI clock speed in Hz.
+    /// * `three_wire` - true: SPI 3-wire mode; false: SPI 4-wire mode.
+    pub fn with_bus(bus: u8,
+                    slave_select: u8,
+                    clock_speed: u32,
+                    three_wire: bool) -> AdxlResult<Self> {
+        let bus = match bus {
+            0 => Bus::Spi0,
+            1 => Bus::Spi1,
+            2 => Bus::Spi2,
+            /*
+            3 => Bus::Spi3,
+            4 => Bus::Spi4,
+            5 => Bus::Spi5,
+            6 => Bus::Spi6,
+            */
+            _ => return Err(AdxlError::InvalidBusParams),
+        };
+        let slave_select = match slave_select {
+            0 => SlaveSelect::Ss0,
+            1 => SlaveSelect::Ss1,
+            2 => SlaveSelect::Ss2,
+            /*
+            3 => SlaveSelect::Ss3,
+            4 => SlaveSelect::Ss4,
+            5 => SlaveSelect::Ss5,
+            6 => SlaveSelect::Ss6,
+            7 => SlaveSelect::Ss7,
+            8 => SlaveSelect::Ss8,
+            9 => SlaveSelect::Ss9,
+            10 => SlaveSelect::Ss10,
+            11 => SlaveSelect::Ss11,
+            12 => SlaveSelect::Ss12,
+            13 => SlaveSelect::Ss13,
+            14 => SlaveSelect::Ss14,
+            15 => SlaveSelect::Ss15,
+            */
+            _ => return Err(AdxlError::InvalidBusParams),
+        };
+        let mut device = Device {
+            bus: Spi::new(bus, slave_select, clock_speed, Mode::Mode3)?,
+            three_wire,
+        };
+        device.init()?;
+        Ok(device)
+    }
+}
+
+impl Adxl345 for Device {}
+impl Adxl345Init for Device {}
+
+impl Adxl345Reader for Device {
+    fn access(&self, register: u8) -> AdxlResult<u8> {
+        let mut read_buf = [0u8, 0u8];
+        debug_assert!(register <= 0x7F);
+        let write_buf = [(register & 0x7Fu8) | 0x80u8, 0u8];
+        self.bus.transfer(&mut read_buf, &write_buf)?;
+        Ok(read_buf[1])
+    }
+    fn acceleration(&self) -> AdxlResult<(i16, i16, i16)> {
+        let register = 0x32;
+        let mut read_buf = [0u8; 7];
+        debug_assert!(register <= 0x7F);
+        let write_buf = [(register & 0x7Fu8) | 0x80u8 | 0x40u8,
+                         0u8, 0u8, 0u8, 0u8, 0u8, 0u8];
+        self.bus.transfer(&mut read_buf, &write_buf)?;
+        Ok((
+            i16::from_le_bytes([read_buf[1], read_buf[2]]),
+            i16::from_le_bytes([read_buf[3], read_buf[4]]),
+            i16::from_le_bytes([read_buf[5], read_buf[6]]),
+        ))
+    }
+}
+
+impl Adxl345Writer for Device {
+    fn command(&mut self, register: u8, byte: u8) -> Result {
+        debug_assert!(register <= 0x7F);
+        let write_buf = [(register & 0x7Fu8), byte];
+        self.bus.write(&write_buf)?;
+        Ok(())
+    }
+    fn init(&mut self) -> Result {
+    	self.init_registers(self.three_wire)
+    }
+}


### PR DESCRIPTION
This pull request adds SPI bus support.

What has been tested: The example/spi.rs returns plausible values in 4-wire-SPI-mode.
What has not been tested: 3-wire-SPI-mode.

I created a private trait that is not exported from the crate to hold methods (mostly) common between busses.

Open question: How should we handle the Bus and SlaveSelect types?
- Should we stay with the current integer to enum mapping? (Note the commented out mappings for newer rppal version).
- Should we re-export the types from rppal?
- Any other ideas?

Please share your thoughts. What other aspects should be improved?
Thanks a lot.