### PR TITLE
Port to embedded-hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ repository = "https://github.com/Dragonrun1/adxl345_driver"
 bitflags = "1.3.2"
 c2rust-bitfields = "0.3.0"
 thiserror = "1.0.32"
-embedded-hal = "=1.0.0-alpha.8"
+embedded-hal = "=1.0.0-alpha.9"
 
 [dev-dependencies]
 anyhow = "1.0.61"
 ctrlc = { version = "3.2.2", features = ["termination"] }
 #XXX: latest rppal release 0.13 doesn't support embedded-hal 1.0, which we need. Go with unreleased version for now.
-rppal = { git = "https://github.com/mbuesch/rppal.git", rev = "b63262939a7693c5f1d245102efaba1a3714b152", features = ["hal"] }
+rppal = { git = "https://github.com/golemparts/rppal.git", rev = "522d76211101261b1dcc153a0eb4d5061e47b789", features = ["hal"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,12 @@ repository = "https://github.com/Dragonrun1/adxl345_driver"
 [dependencies]
 bitflags = "1.3.2"
 c2rust-bitfields = "0.3.0"
-rppal = { version = "0.11.3", features = ["hal", "hal-unproven"] }
 thiserror = "1.0.32"
+embedded-hal = "=1.0.0-alpha.7"
+#embedded-hal = "=1.0.0-alpha.8"
 
 [dev-dependencies]
 anyhow = "1.0.61"
 ctrlc = { version = "3.2.2", features = ["termination"] }
+#XXX: latest rppal release 0.13 doesn't support embedded-hal 1.0, which we need. Go with unreleased version for now.
+rppal = { git = "https://github.com/golemparts/rppal.git", rev = "54e54cbe17293044eaf77bc599631c0ecc572f91", features = ["hal"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,10 @@ repository = "https://github.com/Dragonrun1/adxl345_driver"
 bitflags = "1.3.2"
 c2rust-bitfields = "0.3.0"
 thiserror = "1.0.32"
-embedded-hal = "=1.0.0-alpha.7"
-#embedded-hal = "=1.0.0-alpha.8"
+embedded-hal = "=1.0.0-alpha.8"
 
 [dev-dependencies]
 anyhow = "1.0.61"
 ctrlc = { version = "3.2.2", features = ["termination"] }
 #XXX: latest rppal release 0.13 doesn't support embedded-hal 1.0, which we need. Go with unreleased version for now.
-rppal = { git = "https://github.com/golemparts/rppal.git", rev = "54e54cbe17293044eaf77bc599631c0ecc572f91", features = ["hal"] }
+rppal = { git = "https://github.com/mbuesch/rppal.git", rev = "b63262939a7693c5f1d245102efaba1a3714b152", features = ["hal"] }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # adxl345_driver
 
 This is an implementation of a hardware driver for a [ADXL345] type 3-Axis
-Digital Accelerometer write in [Rust] using the [rppal] library.
+Digital Accelerometer written in [Rust] using [embedded-hal] `I2c` and `Spi` traits.
+That means it runs on all hardware layers that implement the [embedded-hal] traits.
+
 It exposes a simple trait-based API for the command set which minimizes the
 coupling between the hardware driver (I²C, etc) and the code that passes
 commands and data to and from the accelerometer.
@@ -21,15 +23,12 @@ and not the internal workings.
 ## Getting Started
 
 You will need to have a recent version of [Rust] installed.
-Any version of Rust that supports version 0.11.3 or later of [rppal] should
-work but versions from 1.43 to 1.47 of Rust have been used during initial
-development on both the nightly and release channels.
-Earlier versions might work as well but have not been tested.
 
-Development can be done on any OS that Rust supports but the only expected
-output target is a Raspberry Pi running a Linux OS.
-All initial development has been done with a combination of a laptop running
-Windows 10 and a 4GB Raspberry Pi 4 running the Raspberry Pi OS (Raspbian).
+This crate supports all hardware abstraction layers that implement the
+[embedded-hal] `I2c` and `Spi` traits. That includes the [rppal] driver for
+the Raspberry Pi. But it is not restricted to that platform. Platforms
+that are known to work correctly are the Raspberry Pi with [rppal] and the
+ESP32 with [esp-idf-hal]. But this crate is not restricted to these HAL layers.
 
 ### Using The Crate
 
@@ -117,7 +116,9 @@ All documentation like this README is licensed under a
 [Rust]: https://www.rust-lang.org/
 [adxl345_driver]: https://crates.io/crates/adxl345_driver
 [cargo-edit]: https://crates.io/crates/cargo-edit
+[embedded-hal]: https://crates.io/crates/embedded-hal
 [rppal]: https://github.com/golemparts/rppal
+[esp-idf-hal]: https://crates.io/crates/esp-idf-hal
 
 <hr>
 <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -44,7 +44,7 @@
 
 use adxl345_driver::{i2c::Device, Adxl345Reader, Adxl345Writer};
 use anyhow::{Context, Result};
-use rppal::system::DeviceInfo;
+use rppal::{i2c::I2c, system::DeviceInfo};
 use std::{
     sync::atomic::{AtomicBool, Ordering},
     sync::Arc,
@@ -65,7 +65,7 @@ fn main() -> Result<()> {
             .context("Failed to get new DeviceInfo")?
             .model()
     );
-    let mut adxl345 = Device::new().context("Failed to get instance")?;
+    let mut adxl345 = Device::new(I2c::new().context("Failed to create I2C bus.")?).context("Failed to get instance")?;
     let id = adxl345.device_id().context("Failed to get device id")?;
     println!("Device id = {}", id);
     // Set full scale output and range to 2G.

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -45,7 +45,10 @@
 
 use adxl345_driver::{spi::Device, Adxl345Reader, Adxl345Writer};
 use anyhow::{Context, Result};
-use rppal::system::DeviceInfo;
+use rppal::{
+    spi::{Bus, Mode, SlaveSelect, Spi},
+    system::DeviceInfo,
+};
 use std::{
     sync::atomic::{AtomicBool, Ordering},
     sync::Arc,
@@ -66,7 +69,8 @@ fn main() -> Result<()> {
             .context("Failed to get new DeviceInfo")?
             .model()
     );
-    let mut adxl345 = Device::new().context("Failed to get instance")?;
+    let spi = Spi::new(Bus::Spi0, SlaveSelect::Ss0, 1_000_000, Mode::Mode3).context("Failed to create SPI bus")?;
+    let mut adxl345 = Device::new(spi, false).context("Failed to get instance")?;
     let id = adxl345.device_id().context("Failed to get device id")?;
     println!("Device id = {}", id);
     // Set full scale output and range to 2G.

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -46,7 +46,7 @@
 use adxl345_driver::{spi::Device, Adxl345Reader, Adxl345Writer};
 use anyhow::{Context, Result};
 use rppal::{
-    spi::{Bus, Mode, SlaveSelect, Spi},
+    spi::{Bus, Mode, SlaveSelect, Spi, SimpleHalSpiDevice},
     system::DeviceInfo,
 };
 use std::{
@@ -69,7 +69,7 @@ fn main() -> Result<()> {
             .context("Failed to get new DeviceInfo")?
             .model()
     );
-    let spi = Spi::new(Bus::Spi0, SlaveSelect::Ss0, 1_000_000, Mode::Mode3).context("Failed to create SPI bus")?;
+    let spi = SimpleHalSpiDevice::new(Spi::new(Bus::Spi0, SlaveSelect::Ss0, 1_000_000, Mode::Mode3).context("Failed to create SPI bus")?);
     let mut adxl345 = Device::new(spi, false).context("Failed to get instance")?;
     let id = adxl345.device_id().context("Failed to get device id")?;
     println!("Device id = {}", id);

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -82,20 +82,20 @@ pub trait Adxl345Reader {
     /// ## Arguments
     /// * `register` - Register address to be accessed (read).
     ///
-    fn access(&self, register: u8) -> AdxlResult<u8>;
+    fn access(&mut self, register: u8) -> AdxlResult<u8>;
     /// Access the 3-axis of acceleration data together.
-    fn acceleration(&self) -> AdxlResult<(i16, i16, i16)>;
+    fn acceleration(&mut self) -> AdxlResult<(i16, i16, i16)>;
     //
     // ## Shouldn't be a need to change these methods in driver implementations. ##
     //
     // ### Convenience methods which allow accessing registers in related sets.
     //
     /// Access the current free-fall threshold and time values.
-    fn free_fall(&self) -> AdxlResult<(u8, u8)> {
+    fn free_fall(&mut self) -> AdxlResult<(u8, u8)> {
         Ok((self.free_fall_threshold()?, self.free_fall_time()?))
     }
     /// Access all 3-axis of the offset adjustments.
-    fn offset_adjustment(&self) -> AdxlResult<(i8, i8, i8)> {
+    fn offset_adjustment(&mut self) -> AdxlResult<(i8, i8, i8)> {
         Ok((self.x_offset()?, self.y_offset()?, self.z_offset()?))
     }
     /// Access to all non-control tap current values together as a structure.
@@ -103,7 +103,7 @@ pub trait Adxl345Reader {
     /// See [Tap] for more information.
     ///
     /// [Tap]: struct.Tap.html
-    fn tap(&self) -> AdxlResult<Tap> {
+    fn tap(&mut self) -> AdxlResult<Tap> {
         let values = [
             self.tap_threshold()?,
             self.tap_duration()?,
@@ -116,14 +116,14 @@ pub trait Adxl345Reader {
     // ### Per register access methods.
     //
     /// Access the current axis activity/inactivity control mode.
-    fn activity_control(&self) -> AdxlResult<ActivityMode> {
+    fn activity_control(&mut self) -> AdxlResult<ActivityMode> {
         let register = 0x27;
         let data = self.access(register)?;
         let result = ActivityMode::from_bits(data).ok_or(AdxlError::UnknownModeBit(data))?;
         Ok(result)
     }
     /// Access the current activity threshold value.
-    fn activity_threshold(&self) -> AdxlResult<u8> {
+    fn activity_threshold(&mut self) -> AdxlResult<u8> {
         let register = 0x24;
         self.access(register)
     }
@@ -134,122 +134,122 @@ pub trait Adxl345Reader {
     ///
     /// Disabling an axis from participation clears the corresponding source bit
     /// when the next activity or single tap/double tap event occurs.
-    fn activity_tap_status(&self) -> AdxlResult<ATStatus> {
+    fn activity_tap_status(&mut self) -> AdxlResult<ATStatus> {
         let register = 0x2b;
         let data = self.access(register)?;
         let result = ATStatus::from_bits(data).ok_or(AdxlError::UnknownModeBit(data))?;
         Ok(result)
     }
     /// Access the current data rate and power mode control mode.
-    fn bandwidth_rate(&self) -> AdxlResult<BandwidthRateControl> {
+    fn bandwidth_rate(&mut self) -> AdxlResult<BandwidthRateControl> {
         let register = 0x2c;
         self.access(register)?.try_into()
     }
     /// Access the current data format mode.
-    fn data_format(&self) -> AdxlResult<DataFormat> {
+    fn data_format(&mut self) -> AdxlResult<DataFormat> {
         let register = 0x31;
         self.access(register)?.try_into()
     }
     /// Access the device ID.
-    fn device_id(&self) -> AdxlResult<u8> {
+    fn device_id(&mut self) -> AdxlResult<u8> {
         let register = 0x00;
         self.access(register)
     }
     /// Access the current free-fall threshold value.
-    fn free_fall_threshold(&self) -> AdxlResult<u8> {
+    fn free_fall_threshold(&mut self) -> AdxlResult<u8> {
         let register = 0x28;
         self.access(register)
     }
     /// Access the current free-fall threshold value.
-    fn free_fall_time(&self) -> AdxlResult<u8> {
+    fn free_fall_time(&mut self) -> AdxlResult<u8> {
         let register = 0x29;
         self.access(register)
     }
     /// Access the current fifo control mode.
-    fn fifo_control(&self) -> AdxlResult<FifoControl> {
+    fn fifo_control(&mut self) -> AdxlResult<FifoControl> {
         let register = 0x38;
         Ok(self.access(register)?.into())
     }
     /// Access the current fifo status.
-    fn fifo_status(&self) -> AdxlResult<FifoStatus> {
+    fn fifo_status(&mut self) -> AdxlResult<FifoStatus> {
         let register = 0x39;
         self.access(register)?.try_into()
     }
     /// Access the current inactivity threshold value.
-    fn inactivity_threshold(&self) -> AdxlResult<u8> {
+    fn inactivity_threshold(&mut self) -> AdxlResult<u8> {
         let register = 0x25;
         self.access(register)
     }
     /// Access the current inactivity time value.
-    fn inactivity_time(&self) -> AdxlResult<u8> {
+    fn inactivity_time(&mut self) -> AdxlResult<u8> {
         let register = 0x26;
         self.access(register)
     }
     /// Access the current interrupt control mode.
-    fn interrupt_control(&self) -> AdxlResult<IntControlMode> {
+    fn interrupt_control(&mut self) -> AdxlResult<IntControlMode> {
         let register = 0x2e;
         let data = self.access(register)?;
         let result = IntControlMode::from_bits(data).ok_or(AdxlError::UnknownModeBit(data))?;
         Ok(result)
     }
     /// Access the current interrupt mapping mode.
-    fn interrupt_map(&self) -> AdxlResult<IntMapMode> {
+    fn interrupt_map(&mut self) -> AdxlResult<IntMapMode> {
         let register = 0x2f;
         let data = self.access(register)?;
         let result = IntMapMode::from_bits(data).ok_or(AdxlError::UnknownModeBit(data))?;
         Ok(result)
     }
     /// Access the current interrupt source.
-    fn interrupt_source(&self) -> AdxlResult<IntSource> {
+    fn interrupt_source(&mut self) -> AdxlResult<IntSource> {
         let register = 0x30;
         let data = self.access(register)?;
         let result = IntSource::from_bits(data).ok_or(AdxlError::UnknownModeBit(data))?;
         Ok(result)
     }
     /// Access the current power-saving features control mode.
-    fn power_control(&self) -> AdxlResult<PowerControl> {
+    fn power_control(&mut self) -> AdxlResult<PowerControl> {
         let register = 0x2d;
         self.access(register)?.try_into()
     }
     /// Access the current tap control mode.
-    fn tap_control(&self) -> AdxlResult<TapMode> {
+    fn tap_control(&mut self) -> AdxlResult<TapMode> {
         let register = 0x2a;
         let data = self.access(register)?;
         let result = TapMode::from_bits(data).ok_or(AdxlError::UnknownModeBit(data))?;
         Ok(result)
     }
     /// Access the current duration value for tap interrupts.
-    fn tap_duration(&self) -> AdxlResult<u8> {
+    fn tap_duration(&mut self) -> AdxlResult<u8> {
         let register = 0x21;
         self.access(register)
     }
     /// Access the current latency value for tap interrupts.
-    fn tap_latency(&self) -> AdxlResult<u8> {
+    fn tap_latency(&mut self) -> AdxlResult<u8> {
         let register = 0x22;
         self.access(register)
     }
     /// Access the current threshold value for tap interrupts.
-    fn tap_threshold(&self) -> AdxlResult<u8> {
+    fn tap_threshold(&mut self) -> AdxlResult<u8> {
         let register = 0x1d;
         self.access(register)
     }
     /// Access the current window value for tap interrupts.
-    fn tap_window(&self) -> AdxlResult<u8> {
+    fn tap_window(&mut self) -> AdxlResult<u8> {
         let register = 0x23;
         self.access(register)
     }
     /// Access the current x-axis offset adjustment value.
-    fn x_offset(&self) -> AdxlResult<i8> {
+    fn x_offset(&mut self) -> AdxlResult<i8> {
         let register = 0x1e;
         Ok(self.access(register)? as i8)
     }
     /// Access the current y-axis offset adjustment value.
-    fn y_offset(&self) -> AdxlResult<i8> {
+    fn y_offset(&mut self) -> AdxlResult<i8> {
         let register = 0x1f;
         Ok(self.access(register)? as i8)
     }
     /// Access the current z-axis offset adjustment value.
-    fn z_offset(&self) -> AdxlResult<i8> {
+    fn z_offset(&mut self) -> AdxlResult<i8> {
         let register = 0x20;
         Ok(self.access(register)? as i8)
     }
@@ -639,6 +639,16 @@ pub(crate) trait Adxl345Init: Adxl345Writer {
         let register = 0x38;
         self.command(register, 0)?;
         Ok(())
+    }
+}
+
+pub(crate) trait Adxl345AccExtract {
+    fn extract_acceleration(&self, buf: &[u8]) -> (i16, i16, i16) {
+        (
+            i16::from_le_bytes([buf[0], buf[1]]),
+            i16::from_le_bytes([buf[2], buf[3]]),
+            i16::from_le_bytes([buf[4], buf[5]]),
+        )
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,13 +31,10 @@ pub enum AdxlError {
     IllegalWriteAddress(u8),
     /// Used to pass through any underlying I²C errors.
     #[error("I²C interface access failed")]
-    I2c(#[from] rppal::i2c::Error),
+    I2c(String),
     /// Used to pass through any underlying SPI errors.
     #[error("SPI interface access failed")]
-    Spi(#[from] rppal::spi::Error),
-    /// Invalid bus parameters.
-    #[error("Invalid bus parameters")]
-    InvalidBusParams,
+    Spi(String),
     /// Used when given an un-excepted value for a mode.
     #[error("Received one or more set unknown mode bit(s) in value: {0}")]
     UnknownModeBit(u8),

--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -22,7 +22,7 @@
 //! Contains the I²C driver for the device.
 
 use crate::{Adxl345, Adxl345AccExtract, Adxl345Init, Adxl345Reader, Adxl345Writer, AdxlError, AdxlResult, Result};
-use embedded_hal::i2c::{blocking::I2c, SevenBitAddress};
+use embedded_hal::i2c::{I2c, SevenBitAddress};
 
 /// I²C driver structure for the device.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ mod error;
 pub mod i2c;
 pub mod spi;
 
+pub(crate) use crate::cmd::Adxl345AccExtract;
 pub(crate) use crate::cmd::Adxl345Init;
 pub use crate::{
     cmd::{

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -22,95 +22,46 @@
 // SOFTWARE.
 //! Contains the SPI driver for the device.
 
-use rppal::spi::{Bus, Mode, SlaveSelect, Spi};
-
-use crate::{Adxl345, Adxl345Init, Adxl345Reader, Adxl345Writer, AdxlError, AdxlResult, Result};
+use crate::{Adxl345, Adxl345AccExtract, Adxl345Init, Adxl345Reader, Adxl345Writer, AdxlError, AdxlResult, Result};
+use embedded_hal::spi::blocking::{Transfer, Write};
 
 /// SPI driver structure for the device.
 #[derive(Debug)]
-pub struct Device {
-    /// Holds the bus interface from the [RPPAL SPI] peripheral.
-    ///
-    /// [RPPAL SPI]: https://docs.golemparts.com/rppal/0.13.1/rppal/spi/index.html
-    bus: Spi,
+pub struct Device<B> {
+    /// Any bus object implementing the `embedded_hal::spi::blocking::{Transfer, Write}` traits.
+    bus: B,
     /// true: SPI 3-wire mode; false: SPI 4-wire mode.
     three_wire: bool,
 }
 
-impl Device {
-    /// Constructor with default bus parameters.
-    ///
-    /// bus = 0; slave_select = 0; clock_speed = 1 MHz; 4-wire-SPI.
-    pub fn new() -> AdxlResult<Self> {
-        Self::with_bus(0, 0, 1_000_000, false)
-    }
-    /// Constructor with bus index and slave-select index.
+impl<B: Transfer + Write> Device<B> {
+    /// Constructor.
     ///
     /// ## Arguments
-    /// * `bus` - SPI bus index (0-2).
-    /// * `slave_select` - SPI slave-select index (0-2).
-    /// * `clock_speed` - SPI clock speed in Hz.
+    /// * `bus` - Any bus object implementing the `embedded_hal::spi::blocking::{Transfer, Write}` traits.
     /// * `three_wire` - true: SPI 3-wire mode; false: SPI 4-wire mode.
-    pub fn with_bus(
-        bus: u8,
-        slave_select: u8,
-        clock_speed: u32,
-        three_wire: bool,
-    ) -> AdxlResult<Self> {
-        let bus = match bus {
-            0 => Bus::Spi0,
-            1 => Bus::Spi1,
-            2 => Bus::Spi2,
-            /*
-            3 => Bus::Spi3,
-            4 => Bus::Spi4,
-            5 => Bus::Spi5,
-            6 => Bus::Spi6,
-            */
-            _ => return Err(AdxlError::InvalidBusParams),
-        };
-        let slave_select = match slave_select {
-            0 => SlaveSelect::Ss0,
-            1 => SlaveSelect::Ss1,
-            2 => SlaveSelect::Ss2,
-            /*
-            3 => SlaveSelect::Ss3,
-            4 => SlaveSelect::Ss4,
-            5 => SlaveSelect::Ss5,
-            6 => SlaveSelect::Ss6,
-            7 => SlaveSelect::Ss7,
-            8 => SlaveSelect::Ss8,
-            9 => SlaveSelect::Ss9,
-            10 => SlaveSelect::Ss10,
-            11 => SlaveSelect::Ss11,
-            12 => SlaveSelect::Ss12,
-            13 => SlaveSelect::Ss13,
-            14 => SlaveSelect::Ss14,
-            15 => SlaveSelect::Ss15,
-            */
-            _ => return Err(AdxlError::InvalidBusParams),
-        };
-        let mut device = Device {
-            bus: Spi::new(bus, slave_select, clock_speed, Mode::Mode3)?,
-            three_wire,
-        };
+    pub fn new(bus: B, three_wire: bool) -> AdxlResult<Self> {
+        let mut device = Device { bus, three_wire };
         device.init()?;
         Ok(device)
     }
 }
 
-impl Adxl345 for Device {}
-impl Adxl345Init for Device {}
+impl<B: Transfer + Write> Adxl345 for Device<B> {}
+impl<B: Transfer + Write> Adxl345Init for Device<B> {}
+impl<B: Transfer + Write> Adxl345AccExtract for Device<B> {}
 
-impl Adxl345Reader for Device {
-    fn access(&self, register: u8) -> AdxlResult<u8> {
+impl<B: Transfer + Write> Adxl345Reader for Device<B> {
+    fn access(&mut self, register: u8) -> AdxlResult<u8> {
         let mut read_buf = [0u8, 0u8];
         debug_assert!(register <= 0x7F);
         let write_buf = [(register & 0x7Fu8) | 0x80u8, 0u8];
-        self.bus.transfer(&mut read_buf, &write_buf)?;
+        if let Err(e) = self.bus.transfer(&mut read_buf, &write_buf) {
+            return Err(AdxlError::Spi(format!("{:?}", e)));
+        }
         Ok(read_buf[1])
     }
-    fn acceleration(&self) -> AdxlResult<(i16, i16, i16)> {
+    fn acceleration(&mut self) -> AdxlResult<(i16, i16, i16)> {
         let register = 0x32;
         let mut read_buf = [0u8; 7];
         debug_assert!(register <= 0x7F);
@@ -123,20 +74,20 @@ impl Adxl345Reader for Device {
             0u8,
             0u8,
         ];
-        self.bus.transfer(&mut read_buf, &write_buf)?;
-        Ok((
-            i16::from_le_bytes([read_buf[1], read_buf[2]]),
-            i16::from_le_bytes([read_buf[3], read_buf[4]]),
-            i16::from_le_bytes([read_buf[5], read_buf[6]]),
-        ))
+        if let Err(e) = self.bus.transfer(&mut read_buf, &write_buf) {
+            return Err(AdxlError::Spi(format!("{:?}", e)));
+        }
+        Ok(self.extract_acceleration(&read_buf[1..7]))
     }
 }
 
-impl Adxl345Writer for Device {
+impl<B: Transfer + Write> Adxl345Writer for Device<B> {
     fn command(&mut self, register: u8, byte: u8) -> Result {
         debug_assert!(register <= 0x7F);
         let write_buf = [(register & 0x7Fu8), byte];
-        self.bus.write(&write_buf)?;
+        if let Err(e) = self.bus.write(&write_buf) {
+            return Err(AdxlError::Spi(format!("{:?}", e)));
+        }
         Ok(())
     }
     fn init(&mut self) -> Result {

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -23,7 +23,7 @@
 //! Contains the SPI driver for the device.
 
 use crate::{Adxl345, Adxl345AccExtract, Adxl345Init, Adxl345Reader, Adxl345Writer, AdxlError, AdxlResult, Result};
-use embedded_hal::spi::blocking::{Transfer, Write};
+use embedded_hal::spi::blocking::{SpiBus, SpiDevice};
 
 /// SPI driver structure for the device.
 #[derive(Debug)]
@@ -34,7 +34,9 @@ pub struct Device<B> {
     three_wire: bool,
 }
 
-impl<B: Transfer + Write> Device<B> {
+impl<B> Device<B>
+    where B: SpiDevice, B::Bus: SpiBus
+{
     /// Constructor.
     ///
     /// ## Arguments
@@ -47,11 +49,21 @@ impl<B: Transfer + Write> Device<B> {
     }
 }
 
-impl<B: Transfer + Write> Adxl345 for Device<B> {}
-impl<B: Transfer + Write> Adxl345Init for Device<B> {}
-impl<B: Transfer + Write> Adxl345AccExtract for Device<B> {}
+impl<B> Adxl345 for Device<B>
+    where B: SpiDevice, B::Bus: SpiBus
+{}
 
-impl<B: Transfer + Write> Adxl345Reader for Device<B> {
+impl<B> Adxl345Init for Device<B>
+    where B: SpiDevice, B::Bus: SpiBus
+{}
+
+impl<B> Adxl345AccExtract for Device<B>
+    where B: SpiDevice, B::Bus: SpiBus
+{}
+
+impl<B> Adxl345Reader for Device<B>
+    where B: SpiDevice, B::Bus: SpiBus
+{
     fn access(&mut self, register: u8) -> AdxlResult<u8> {
         let mut read_buf = [0u8, 0u8];
         debug_assert!(register <= 0x7F);
@@ -81,7 +93,9 @@ impl<B: Transfer + Write> Adxl345Reader for Device<B> {
     }
 }
 
-impl<B: Transfer + Write> Adxl345Writer for Device<B> {
+impl<B> Adxl345Writer for Device<B>
+    where B: SpiDevice, B::Bus: SpiBus
+{
     fn command(&mut self, register: u8, byte: u8) -> Result {
         debug_assert!(register <= 0x7F);
         let write_buf = [(register & 0x7Fu8), byte];

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -23,7 +23,7 @@
 //! Contains the SPI driver for the device.
 
 use crate::{Adxl345, Adxl345AccExtract, Adxl345Init, Adxl345Reader, Adxl345Writer, AdxlError, AdxlResult, Result};
-use embedded_hal::spi::blocking::{SpiBus, SpiDevice};
+use embedded_hal::spi::{SpiBus, SpiDevice};
 
 /// SPI driver structure for the device.
 #[derive(Debug)]


### PR DESCRIPTION
This change removes the direct dependency on `rppal` and introduces an `embedded-hal` based `trait I2c` and `trait Spi` bus interface.
That has the major advantage of much higher compatibility with all kinds of hardware abstraction layers, `rppal` included.

TODO:
- It requires an alpha version of `embedded-hal`. rppal with support for embedded-hal 1.0.0-alpha.9 is on its way, ~~but not fully merged, yet.~~ but is not released on crates.io, yet.
- ~~`embedded-hal alpha.8` is the latest one, as of now. It currently doesn't work, because the Spi trait has changed slightly. But easy to fix, once we get rid of `alpha.7` in `rppal`.~~ (Has been solved)
- ~~It requires an unreleased version of `rppal`. The examples currently use a crate generated from the `rppal` git repository.~~ The examples require an unreleased version of `rppal`. (The library itself does not depend on `rppal` anymore.)