### PR TITLE
Remove std dependencies and mark the crate #![no_std]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,13 @@ repository = "https://github.com/Dragonrun1/adxl345_driver"
 
 [dependencies]
 bitflags = "1.3.2"
-c2rust-bitfields = "0.3.0"
+c2rust-bitfields = { version = "0.3.0", features = ["no_std"], default_features = false }
 rppal = { version = "0.11.3", features = ["hal", "hal-unproven"] }
-thiserror = "1.0.32"
 
 [dev-dependencies]
 anyhow = "1.0.61"
 ctrlc = { version = "3.2.2", features = ["termination"] }
+
+[features]
+default = []
+no_std = []

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Which should add something like this in your [Cargo.toml]:
 
 ```toml
 [dependencies]
-adxl345_driver = "0.0.5"
+adxl345_driver = "0.0.8"
 ```
 
 ## Examples
@@ -85,6 +85,21 @@ axis: {'x': 1.6475, 'y': 0.1177, 'z': 8.8260} m/s²
 ```
 
 You can find the latest version by go to [adxl345_driver] on the crates.io website.
+
+## no_std
+
+This crate can be used in `no_std` environments.
+Just enable the `no_std` feature, if you want to build without `std` library.
+
+Please note that this crate currently depends on `rppal`, which in turn depends
+on `std`. Therefore, it's currently not possible to have a bin package without
+`std`. This restriction is currently being worked on.
+
+```
+```toml
+[dependencies]
+adxl345_driver = { version = "0.0.8", features = ["no_std"] }
+```
 
 ## Contributing
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -59,7 +59,7 @@
 //! [ADXL345 Datasheet]: https://www.analog.com/media/en/technical-documentation/data-sheets/ADXL345.pdf
 
 use crate::{AdxlError, AdxlResult, Result};
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 /// Complete R/W register command set for the accelerometer.
 pub trait Adxl345: Adxl345Reader + Adxl345Writer {}
@@ -756,7 +756,7 @@ pub struct BandwidthRateControl {
 
 impl TryFrom<u8> for BandwidthRateControl {
     type Error = AdxlError;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> core::result::Result<Self, Self::Error> {
         // Bit-wise AND with negative mask of allowed bitfields.
         if value & !0x1f == 0 {
             Ok(Self { byte: [value; 1] })
@@ -817,7 +817,7 @@ pub struct DataFormat {
 impl TryFrom<u8> for DataFormat {
     type Error = AdxlError;
     //noinspection DuplicatedCode
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> core::result::Result<Self, Self::Error> {
         // Bit-wise AND with negative mask of allowed bitfields.
         if value & !0xef == 0 {
             Ok(Self { byte: [value; 1] })
@@ -893,7 +893,7 @@ pub struct FifoStatus {
 impl TryFrom<u8> for FifoStatus {
     type Error = AdxlError;
     //noinspection DuplicatedCode
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> core::result::Result<Self, Self::Error> {
         // Bit-wise AND with negative mask of allowed bitfields.
         if value & !0xbf == 0 {
             Ok(Self { byte: [value; 1] })
@@ -1091,7 +1091,7 @@ pub struct PowerControl {
 impl TryFrom<u8> for PowerControl {
     type Error = AdxlError;
     //noinspection DuplicatedCode
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> core::result::Result<Self, Self::Error> {
         // Bit-wise AND with negative mask of allowed bitfields.
         if value & !0x3f == 0 {
             Ok(Self { byte: [value; 1] })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@
 //!
 //! This is meant to be a hardware level driver interface for the device.
 
+#![cfg_attr(no_std, no_std)]
+
 #[macro_use]
 extern crate bitflags;
 #[macro_use]


### PR DESCRIPTION
This change removes all std dependencies, except for `rppal` and marks the crate `#![no_std]`. no_std is a must for small embedded microcontrollers.

The only real feature loss due to this is the sophisticated `thiserror` based error handling.
But quite honestly, I don't really think this is a loss. We could try to tweak the new implementation a bit to get more information from low level upstream, but I really doubt there's any use of that information. If there's an error during bus access, then there's something physically wrong with the bus. No low level error code will really help here.